### PR TITLE
Fix ranking

### DIFF
--- a/suivi_tarot/api/calcul.py
+++ b/suivi_tarot/api/calcul.py
@@ -138,19 +138,25 @@ def distribution_point_between_attack_defense(result: int,
     return preneur, appele, defense
 
 
-def repartition_points_by_player(donne: dict, player: str) -> int:
+def repartition_points_by_player(donne: dict, player: str, table_of: int) -> int:
     """Retourne les points à attribuer un à joueur en fonction de son rôle
     dans une donne"""
     nickname = player
 
-    if nickname in [donne['pnj'], donne['preneur'], donne['appele']]:
-        if nickname == donne['pnj']:
-            return 0
-        elif nickname == donne['appele']:
-            return donne['result']
-        else:
-            return donne['result'] * 4 if donne['appele'] in ['Chien', 'Solo'] else donne['result'] * 2
-    elif nickname in [donne['defense1'], donne['defense2'], donne['defense3'], donne['defense4']]:
-        return donne['result'] * -1
-    else:
-        return 0
+    match table_of:
+        case 5:
+            if nickname in [donne['pnj'], donne['preneur'], donne['appele']]:
+                if nickname == donne['pnj']:
+                    return 0
+                elif nickname == donne['appele']:
+                    return donne['result']
+                else:
+                    return donne['result'] * 4 if donne['appele'] in ['Chien', 'Solo'] else donne['result'] * 2
+            elif nickname in [donne['defense1'], donne['defense2'], donne['defense3'], donne['defense4']]:
+                return donne['result'] * -1
+            else:
+                return 0
+        case 4:
+            return donne['result'] * 3 if nickname == donne['preneur'] else donne['result'] * -1
+        case 3:
+            return donne['result'] * 2 if nickname == donne['preneur'] else donne['result'] * -1

--- a/suivi_tarot/api/calcul.py
+++ b/suivi_tarot/api/calcul.py
@@ -157,6 +157,14 @@ def repartition_points_by_player(donne: dict, player: str, table_of: int) -> int
             else:
                 return 0
         case 4:
-            return donne['result'] * 3 if nickname == donne['preneur'] else donne['result'] * -1
+            if nickname == donne['preneur']:
+                return donne['result'] * 3
+            elif nickname in [donne['defense1'], donne['defense2'], donne['defense3']]:
+                return donne['result'] * -1
+            return 0
         case 3:
-            return donne['result'] * 2 if nickname == donne['preneur'] else donne['result'] * -1
+            if nickname == donne['preneur']:
+                return donne['result'] * 2
+            elif nickname in [donne['defense1'], donne['defense2']]:
+                return donne['result'] * -1
+            return 0

--- a/suivi_tarot/api/ranking.py
+++ b/suivi_tarot/api/ranking.py
@@ -72,7 +72,8 @@ class Ranking:
         """Ajoute une colonne pour chaque joueur au DataFrame donne et calcul les points
         du joueur pour chaque donne"""
         for player in self.distinct_player:
-            self.donne[player] = self.donne.apply(repartition_points_by_player, axis=1, player=player)
+            self.donne[player] = self.donne.apply(repartition_points_by_player,
+                                                  axis=1, player=player, table_of=self.table_of)
             self.cumul[player] = self.donne[player]
 
     def cumulative_points_per_game(self):


### PR DESCRIPTION
Le calcul de répartition des points pour l'affichage du classement ne tenait pas compte du nombre de joueurs composant la partie. C'était le système de répartition à 5 joueurs qui était systématiquement utilisé.